### PR TITLE
feat: add two rules for managing BREAKING CHANGE vs git-trailer

### DIFF
--- a/commisery/rules.py
+++ b/commisery/rules.py
@@ -18,7 +18,7 @@ import re
 
 import llvm_diagnostics as logging
 
-from commisery.commit import CommitMessage
+from commisery.commit import BREAKING_CHANGE_TOKEN, CommitMessage
 from commisery.config import Configuration, get_default_rules
 
 
@@ -471,6 +471,31 @@ def C020_git_trailer_contains_whitespace(
                 line=f"{item.token}: {item.value[0]}",
                 column_number=logging.Range(0, len(item.token)),
             )
+
+
+def C022_footer_contains_blank_line(
+    message: CommitMessage, _: Configuration
+):  # pylint: disable=C0103
+    """Footer should not contain any blank line(s)"""
+    for item in message.footers:
+        if not item.token or len(item.value) == 0:
+            raise logging.Error(
+                message=C022_footer_contains_blank_line.__doc__,
+            )
+
+
+def C023_breaking_change_must_be_first_git_trailer(
+    message: CommitMessage, _: Configuration
+):  # pylint: disable=C0103
+    """The BREAKING CHANGE git-trailer should be the first element in the footer"""
+    for idx, item in enumerate(message.footers):
+        if item.token == BREAKING_CHANGE_TOKEN:
+            if idx != 0:
+                raise logging.Error(
+                    message=C023_breaking_change_must_be_first_git_trailer.__doc__,
+                    line=f"{item.token}: {item.value[0]}",
+                    column_number=logging.Range(0, len(item.token)),
+                )
 
 
 def validate_commit_message_rule(

--- a/commisery/test/test_commit.py
+++ b/commisery/test/test_commit.py
@@ -201,13 +201,13 @@ This should reduce the amount of Jenkins master/slave interactions and
 their associated Groovy script engine "context switches" (state
 serialization and restoration). As a result performance should increase.
 
+vv The next two trailers will be rejected as there is a blank line inbetween vv
 Addresses #279 by adding a test framework.
-
-^^ the above line will be removed due to the fact that text has been injected inbetween footers
-
 Addresses #301 due to the performance improvements
  made to the scripting engine
 
+Addresses #167 by updating testing framework dependencies
+ and validating behavior
 Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
 Acked-by: Joost Muller <Joost.Muller@tomtom.com>
 Acked-by: Martijn Leijssen <Martijn.Leijssen@tomtom.com>
@@ -218,12 +218,17 @@ Merged-by: Hopic 0.10.2.dev7+g840ca0c
     assert message.type == "improvement"
     assert message.scope == "groovy"
 
+    # NOTE: Unfortunately we cannot make a correct judgement for the
+    #       rejected git-trailers, for now we will ignore them and
+    #       they will be considered to be part of the body of the
+    #       commit message.
+
     assert message.footers == [
         Footer(
             "Addresses",
             [
-                "#301 due to the performance improvements",
-                " made to the scripting engine",
+                "#167 by updating testing framework dependencies",
+                " and validating behavior",
             ],
         ),
         Footer("Acked-by", ["Anton Indrawan <Anton.Indrawan@tomtom.com>"]),

--- a/commisery/test/test_rules.py
+++ b/commisery/test/test_rules.py
@@ -361,7 +361,7 @@ def test_C019_subject_contains_issue_reference(message, exception):
             dedent(
                 """\
                 fix: add something
-                
+
                 Addresses #12
                 Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
             """
@@ -372,7 +372,7 @@ def test_C019_subject_contains_issue_reference(message, exception):
             dedent(
                 """\
                 fix: add something
-                
+
                 Addresses #12
                 Acked-by : Anton Indrawan <Anton.Indrawan@tomtom.com>
             """
@@ -383,14 +383,191 @@ def test_C019_subject_contains_issue_reference(message, exception):
             dedent(
                 """\
                 fix: add something
-                
+
                 Addresses #12
                 Acked by: Anton Indrawan <Anton.Indrawan@tomtom.com>
             """
             ),
             True,
         ),
+        (
+            dedent(
+                """\
+                Merge #13: feat: add documentation publication
+
+                * feat: add documentation publication
+
+                    Implements NAV-27889
+
+                    Signed-off-by: Alexandru Lazarescu <alexandru.lazarescu@tomtom.com>
+
+                * feat: add documentation publication
+
+                    Implements NAV-27889
+
+                    Signed-off-by: Alexandru Lazarescu <alexandru.lazarescu@tomtom.com>
+
+                Acked by: Martijn Leijssen <Martijn.Leijssen@tomtom.com>
+                Merged-by: Hopic 1.22.1.dev37+g1b1a265
+                """
+            ),
+            True
+        ),
+        (
+            dedent(
+                """\
+                Merge #13: feat: add documentation publication
+
+                * feat: add documentation publication
+
+                    Implements NAV-27889
+
+                    Signed-off-by: Alexandru Lazarescu <alexandru.lazarescu@tomtom.com>
+
+                * feat: add documentation publication
+
+                    Implements NAV-27889
+
+                    Signed-off-by: Alexandru Lazarescu <alexandru.lazarescu@tomtom.com>
+
+                Acked-by: Martijn Leijssen <Martijn.Leijssen@tomtom.com>
+                Merged-by: Hopic 1.22.1.dev37+g1b1a265
+                """
+            ),
+            False,
+        ),
     ),
 )
 def test_C020_git_trailer_contains_whitespace(message, exception):
     __validate_rule(rules.C020_git_trailer_contains_whitespace, message, exception)
+
+
+@pytest.mark.parametrize(
+    "message, exception",
+    (
+        (
+            dedent(
+                """\
+                fix: add something
+
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                Addresses #12
+
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                BREAKING-CHANGE: This is a breaking change
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                BREAKING-CHANGE: This is a breaking change
+
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                BREAKING-CHANGE: This is a breaking change
+
+                Addresses #12
+
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            True,
+        ),
+    ),
+)
+def test_C022_footer_contains_blank_line(message, exception):
+    __validate_rule(rules.C022_footer_contains_blank_line, message, exception)
+
+
+@pytest.mark.parametrize(
+    "message, exception",
+    (
+        (
+            dedent(
+                """\
+                fix: add something
+
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                BREAKING-CHANGE: This is a breaking change
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                BREAKING-CHANGE: This is a breaking change
+
+                Addresses #12
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            False,
+        ),
+        (
+            dedent(
+                """\
+                fix: add something
+
+                Addresses #12
+                BREAKING-CHANGE: This is a breaking change
+
+                Acked-by: Anton Indrawan <Anton.Indrawan@tomtom.com>
+            """
+            ),
+            True,
+        ),
+    ),
+)
+def test_C023_breaking_change_must_be_first_git_trailer(message, exception):
+    __validate_rule(
+        rules.C023_breaking_change_must_be_first_git_trailer, message, exception
+    )


### PR DESCRIPTION
Parsing the Footer of the commit message is now following these rules:

* Any blank line between trailers will discard the previously parsed trailers (and consider those part of the body)
* Exception: any line (incl. blank lines) following a BREAKING CHANGE will be considered part of the footer

The following two rules have been created to assist users:

### The BREAKING CHANGE git-trailer should be the first element in the footer

As BREAKING CHANGE is an exception (and part of Conventional Commits), we expect this to be the first item in the footer

### Footer should not contain any blank line(s)

Considering that the BREAKING CHANGE trailer indicates the start of the Footer
- a blank line directly following the BREAKING CHANGE is permitted (in accordance to convention)
- any subsequent blank line will be flagged as error (git-trailer spec)