### PR TITLE
feat: extend error messages with file and line number metadata

### DIFF
--- a/commisery/rules.py
+++ b/commisery/rules.py
@@ -482,6 +482,7 @@ def validate_commit_message_rule(
             get_default_rules()[rule].get("obj")(message, config)
     except logging.Error as err:
         err.message = f"[{rule}] {err.message}"
+        err.file_path = message.hexsha
         err.report()
         return 1
 


### PR DESCRIPTION
This commit will add a reference to the commit (HEXSHA, input file, ...)
to the error messages. This will automatically result in the exposure of
line number within the file, i.e.:

`42bc9bbe896357a588c70d9260f4d0f3af08f816:1:18: error: [C003] The commit message's description should not start with a capital case letter`
instead of:
`error: [C003] The commit message's description should not start with a capital case letter`