### PR TITLE
chore: import versioning module from Hopic

### DIFF
--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -4,10 +4,10 @@ import re
 import subprocess
 import sys
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
+from io import (
+        StringIO,
+        open,
+    )
 
 __all__ = (
         'SemVer',
@@ -48,7 +48,7 @@ class SemVer(object):
             ver += '+' + str(self.build)
         return ver
 
-    version_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?$')
+    version_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?\s*$')
     @classmethod
     def parse(cls, s):
         m = cls.version_re.match(s)
@@ -185,19 +185,19 @@ _fmts = {
         'semver': SemVer,
     }
 
-def read_version(fname, format='semver'):
+def read_version(fname, format='semver', encoding=None):
     fmt = _fmts[format]
 
-    with open(fname, 'r') as f:
+    with open(fname, 'r', encoding=encoding) as f:
         for line in f:
             version = fmt.parse(line)
             if version is not None:
                 return version
 
-def replace_version(fname, new_version):
+def replace_version(fname, new_version, encoding=None):
 
     new_content = StringIO()
-    with open(fname, 'r') as f:
+    with open(fname, 'r', encoding=encoding) as f:
         for line in f:
             # Replace version in source line
             m = new_version.version_re.match(line)
@@ -205,5 +205,5 @@ def replace_version(fname, new_version):
                 line = line[:m.start(1)] + str(new_version) + line[m.end(m.lastgroup)]
             new_content.write(line)
 
-    with open(fname, 'w') as f:
+    with open(fname, 'w', encoding=encoding) as f:
         f.write(new_content.getvalue())

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -281,7 +281,7 @@ class CarusoVer(object):
         ver = '.'.join(str(x) for x in tuple(self)[:3])
         if self.prerelease:
             ver += '-' + str(self.prerelease)
-        ver += '+PI{self.increment}.{self.fix}'.format(self=self)
+        ver += f"+PI{self.increment}.{self.fix}"
         return ver
 
     version_re = re.compile(
@@ -456,7 +456,7 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
     else:
         tag_name = description
 
-    assert format == 'semver', "Wrong format: {format}".format(**locals())
+    assert format == 'semver', f"Wrong format: {format}"
     tag_version = SemVer.parse(_git_describe_semver_tag_cleanup.sub('', tag_name))
     if tag_version is None:
         return None

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from datetime import datetime
+import logging
 import os
 import re
 
@@ -27,6 +28,8 @@ __all__ = (
     'read_version',
     'replace_version',
 )
+
+log = logging.getLogger(__name__)
 
 
 class _IdentifierList(tuple):
@@ -462,8 +465,10 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
         tag_name = description
 
     assert format == 'semver', f"Wrong format: {format}"
-    tag_version = SemVer.parse(_git_describe_semver_tag_cleanup.sub('', tag_name))
+    version_part = _git_describe_semver_tag_cleanup.sub('', tag_name)
+    tag_version = SemVer.parse(version_part)
     if tag_version is None:
+        log.warning('Failed to parse version string %r as %s', version_part, format)
         return None
 
     if (commit_count or dirty) and not tag_version.prerelease:

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 - 2020 TomTom N.V. (https://tomtom.com)
+# Copyright (c) 2018 - 2021 TomTom N.V. (https://tomtom.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -523,7 +523,7 @@ class GitVersion(NamedTuple):
 def replace_version(fname, new_version, encoding=None, outfile=None):
 
     if outfile is None:
-        out = temp = open(fname + '.tmp', 'w', encoding=encoding)
+        out = temp = open(fname.with_suffix(fname.suffix + ".tmp"), "w", encoding=encoding)
     else:
         out = outfile
         temp = None

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -178,6 +178,17 @@ class SemVer(object):
             'major':      self.next_major,
         }[bump](*args, **kwargs)
 
+    def next_version_for_commits(self, commits):
+        has_new_feature = False
+        for commit in commits:
+            if commit.has_breaking_change():
+                return self.next_major()
+            if commit.has_new_feature():
+                has_new_feature = True
+        if has_new_feature:
+            return self.next_minor()
+        return self.next_patch()
+
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):
             return NotImplemented
@@ -345,6 +356,9 @@ class CarusoVer(object):
             'prerelease': self.next_prerelease,
             'fix':        self.next_fix,
         }[bump](*args, **kwargs)
+
+    def next_version_for_commits(self, commits):
+        raise NotImplementedError
 
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -444,9 +444,16 @@ class CarusoVer(object):
 _rejected_hotfix_prefixes = frozenset((
     "a",
     "b",
+    "c",
     "rc",
     "alpha",
     "beta",
+    "pre",
+    "preview",
+    "post",
+    "rev",
+    "r",
+    "dev",
 ))
 
 

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -450,6 +450,10 @@ class GitVersion(NamedTuple):
     commit_count : Optional[int] = None
     commit_hash  : Optional[str] = None
 
+    @property
+    def exact(self):
+        return not self.dirty and self.commit_count == 0
+
     # NOTE: while this is a regular language, it's one who's captures cannot be described if put in a single regex
     _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
     _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -482,7 +482,7 @@ def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Tuple[str
     if re.sub(r"[0-9]+$", "", prefix) in _rejected_hotfix_prefixes:
         raise VersioningError(f"Hotfix ID '{hotfix}' starts with reserved prefix {prefix}")
 
-    return tuple(hotfix.split("."))
+    return _IdentifierList(hotfix.split("."))
 
 
 _fmts = {

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,0 +1,96 @@
+from .execution import echo_cmd
+import click
+import re
+import subprocess
+import sys
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+__all__ = (
+        'bump_version',
+    )
+
+_semver_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?$')
+def parse_semver(s):
+    m = _semver_re.match(s)
+    if not m:
+        return None
+
+    major, minor, patch, prerelease, build = m.groups()
+
+    major, minor, patch = int(major), int(minor), int(patch)
+
+    if prerelease is None:
+        prerelease = ()
+    else:
+        prerelease = tuple(prerelease.split('.'))
+
+    if build is None:
+        build = ()
+    else:
+        build = tuple(build.split('.'))
+
+    return (major, minor, patch, prerelease, build)
+
+def stringify_semver(major, minor, patch, prerelease, build):
+    ver = '.'.join(str(x) for x in (major, minor, patch))
+    if prerelease:
+        ver += '-' + '.'.join(prerelease)
+    if build:
+        ver += '+' + '.'.join(build)
+    return ver
+
+def bump_version(workspace, file, format='semver', bump='patch', **_):
+    version = None
+    new_content = StringIO()
+    with open(file, 'r') as f:
+        for l in f:
+            ver = None
+            if format == 'semver':
+                ver = parse_semver(l)
+            if ver is None:
+                new_content.write(l)
+                continue
+
+            assert version is None, "multiple versions are not supported"
+            version = ver
+
+            if bump:
+                major, minor, patch, prerelease, build = version
+
+                if bump == 'patch':
+                    if not prerelease:
+                        patch += 1
+                elif bump == 'minor':
+                    if not (prerelease and patch == 0):
+                        minor += 1
+                    patch = 0
+                elif bump == 'major':
+                    if not (prerelease and minor == 0 and patch == 0):
+                        major += 1
+                    major = 0
+                    minor = 0
+                else:
+                    click.echo("Invalid version bumping target: {bump}".format(**locals()), err=True)
+                    sys.exit(1)
+
+                # When bumping the prerelease tags need to be dropped always
+                prerelease, build = (), ()
+
+                version = (major, minor, patch, prerelease, build)
+
+                # Replace version in source line
+                m = _semver_re.match(l)
+                new_line = l[:m.start(1)] + stringify_semver(*version) + l[m.end(m.lastgroup)]
+                new_content.write(new_line)
+
+    if bump:
+        assert version is not None, "no version found"
+        with open(file, 'w') as f:
+            f.write(new_content.getvalue())
+        echo_cmd(subprocess.check_call, ('git', 'add', file), cwd=workspace)
+
+    return (stringify_semver(*version) if version is not None else version)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -50,7 +50,7 @@ class SemVer(object):
             ver += '+' + str(self.build)
         return ver
 
-    version_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?\s*$')
+    version_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z]+)*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z]+)*))?\s*$')
     @classmethod
     def parse(cls, s):
         m = cls.version_re.match(s)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,9 +1,5 @@
-from .execution import echo_cmd
-import click
 from datetime import datetime
 import re
-import subprocess
-import sys
 
 from io import (
         StringIO,

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -58,7 +58,7 @@ class SemVer(object):
     default_tag_name = '{version.major}.{version.minor}.{version.patch}'
 
     def __init__(self, major, minor, patch, prerelease, build):
-        super(SemVer, self).__init__()
+        super().__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch
@@ -67,9 +67,9 @@ class SemVer(object):
 
     def __setattr__(self, name, value):
         if name in {'major', 'minor', 'patch'}:
-            return super(SemVer, self).__setattr__(name, int(value))
+            return super().__setattr__(name, int(value))
         elif name in {'prerelease', 'build'}:
-            return super(SemVer, self).__setattr__(name, _IdentifierList(value))
+            return super().__setattr__(name, _IdentifierList(value))
 
     def __iter__(self):
         return iter(getattr(self, attr) for attr in self.__class__.__slots__)
@@ -258,7 +258,7 @@ class CarusoVer(object):
     default_tag_name = '{version.major}.{version.minor}.{version.patch}+PI{version.increment}.{version.fix}'
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
-        super(CarusoVer, self).__init__()
+        super().__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch
@@ -268,9 +268,9 @@ class CarusoVer(object):
 
     def __setattr__(self, name, value):
         if name in {'major', 'minor', 'patch', 'increment', 'fix'}:
-            return super(CarusoVer, self).__setattr__(name, int(value))
+            return super().__setattr__(name, int(value))
         elif name in {'prerelease'}:
-            return super(CarusoVer, self).__setattr__(name, _IdentifierList(value))
+            return super().__setattr__(name, _IdentifierList(value))
 
     def __iter__(self):
         return iter(getattr(self, attr) for attr in self.__class__.__slots__)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -48,7 +48,7 @@ def stringify_semver(major, minor, patch, prerelease, build):
     return ver
 
 _number_re = re.compile(r'^\d+$')
-def bump_version(workspace, file, format='semver', bump='prerelease', **_):
+def bump_version(workspace, file, format='semver', bump='prerelease'):
     version = None
     new_content = StringIO()
     with open(file, 'r') as f:

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -227,10 +227,6 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
     if tag_version is None:
         return None
 
-    if dirty and commit_count is None:
-        # Ensure that 'dirty' commits sort before the next non-dirty commit
-        commit_count = 0
-
     if (commit_count or dirty) and not tag_version.prerelease:
         tag_version = tag_version.next_patch()
 
@@ -239,6 +235,9 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
     if dirty:
         if dirty_date is None:
             dirty_date = datetime.utcnow()
+        if not commit_count:
+            # Ensure that 'dirty' commits sort before the next non-dirty commit
+            tag_version.prerelease = tag_version.prerelease + ('0',)
         tag_version.prerelease = tag_version.prerelease + ('dirty', dirty_date.strftime('%Y%m%d%H%M%S'))
     if abbrev_commit_hash is not None:
         tag_version.build = tag_version.build + ('g' + abbrev_commit_hash,)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,5 +1,6 @@
 from .execution import echo_cmd
 import click
+from datetime import datetime
 import re
 import subprocess
 import sys
@@ -201,7 +202,7 @@ def read_version(fname, format='semver', encoding=None):
 _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
 _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')
 _git_describe_semver_tag_cleanup = re.compile(r'^[^0-9]+')
-def parse_git_describe_version(description, format='semver'):
+def parse_git_describe_version(description, format='semver', dirty_date=None):
     dirty = description.endswith('-dirty')
     if dirty:
         description = description[:-len('-dirty')]
@@ -234,7 +235,8 @@ def parse_git_describe_version(description, format='semver'):
     if commit_count:
         tag_version.prerelease = tag_version.prerelease + (str(commit_count),)
     if dirty:
-        dirty_date = commit_date or author_date or datetime.utcnow()
+        if dirty_date is None:
+            dirty_date = datetime.utcnow()
         tag_version.prerelease = tag_version.prerelease + ('dirty', dirty_date.strftime('%Y%m%d%H%M%S'))
     if abbrev_commit_hash != None:
         tag_version.build = tag_version.build + ('g' + abbrev_commit_hash,)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -466,9 +466,10 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
 def replace_version(fname, new_version, encoding=None, outfile=None):
 
     if outfile is None:
-        out = open(fname + '.tmp', 'w', encoding=encoding)
+        out = temp = open(fname + '.tmp', 'w', encoding=encoding)
     else:
         out = outfile
+        temp = None
 
     try:
         with open(fname, 'r', encoding=encoding) as f:
@@ -479,11 +480,11 @@ def replace_version(fname, new_version, encoding=None, outfile=None):
                     line = line[:m.start(1)] + str(new_version) + line[m.end(m.lastgroup)]
                 out.write(line)
     except:  # noqa: E722: we re-raise, so it's not a problem
-        if outfile is None:
-            out.close()
-            os.remove(fname + '.tmp')
+        if temp is not None:
+            temp.close()
+            os.remove(temp.name)
         raise
     else:
-        if outfile is None:
-            out.close()
-            os.rename(fname + '.tmp', fname)
+        if temp is not None:
+            temp.close()
+            os.rename(temp.name, fname)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -15,7 +15,6 @@
 from datetime import datetime
 import os
 import re
-from six import string_types
 
 from io import (
     open,
@@ -142,7 +141,7 @@ class SemVer(object):
     def next_prerelease(self, seed=None):
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
-            if isinstance(seed, string_types):
+            if isinstance(seed, str):
                 seed = (seed,)
             elif not seed:
                 seed = ('1',)
@@ -323,7 +322,7 @@ class CarusoVer(object):
     def next_prerelease(self, seed=None):
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
-            if isinstance(seed, string_types):
+            if isinstance(seed, str):
                 seed = (seed,)
             elif not seed:
                 seed = ('1',)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -454,6 +454,9 @@ def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Optional[
     """
     Extracts a hotfix ID from a hotfix branch name using the given regular expression.
     """
+    if branch_name is None:
+        return None
+
     if not isinstance(pat, Pattern):
         pat = re.compile(pat)
 

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -91,10 +91,10 @@ class Version(Protocol):
 
     def __eq__(self, rhs: Any) -> bool: ...
     def __ne__(self, rhs: Any) -> bool: ...
-    def __lt__(self, rhs: Any) -> bool: ...
-    def __le__(self, rhs: Any) -> bool: ...
-    def __gt__(self, rhs: Any) -> bool: ...
-    def __ge__(self, rhs: Any) -> bool: ...
+    def __lt__(self, rhs: "Version") -> bool: ...
+    def __le__(self, rhs: "Version") -> bool: ...
+    def __gt__(self, rhs: "Version") -> bool: ...
+    def __ge__(self, rhs: "Version") -> bool: ...
 
 
 class SemVer(Version):
@@ -278,7 +278,7 @@ class SemVer(Version):
             return NotImplemented
         return False
 
-    def __lt__(self, rhs: object) -> bool:
+    def __lt__(self, rhs: Version) -> bool:
         if not isinstance(rhs, self.__class__):
             return NotImplemented
         if tuple(self)[:3] < tuple(rhs)[:3]:
@@ -317,13 +317,13 @@ class SemVer(Version):
 
         return len(self.prerelease) < len(rhs.prerelease)
 
-    def __le__(self, rhs):
+    def __le__(self, rhs: Version) -> bool:
         return self < rhs or tuple(self)[:-1] == tuple(rhs)[:-1]
 
-    def __gt__(self, rhs: object) -> bool:
+    def __gt__(self, rhs: Version) -> bool:
         return rhs < self
 
-    def __ge__(self, rhs: object) -> bool:
+    def __ge__(self, rhs: Version) -> bool:
         return rhs <= self
 
 
@@ -450,7 +450,7 @@ class CarusoVer(Version):
             return NotImplemented
         return tuple(self) != tuple(rhs)
 
-    def __lt__(self, rhs: object) -> bool:
+    def __lt__(self, rhs: Version) -> bool:
         if not isinstance(rhs, self.__class__):
             return NotImplemented
         lhs_t = tuple(self)[:3] + tuple(self)[4:6]
@@ -491,13 +491,13 @@ class CarusoVer(Version):
 
         return len(self.prerelease) < len(rhs.prerelease)
 
-    def __le__(self, rhs: object) -> bool:
+    def __le__(self, rhs: Version) -> bool:
         return self < rhs or self == rhs
 
-    def __gt__(self, rhs: object) -> bool:
+    def __gt__(self, rhs: Version) -> bool:
         return rhs < self
 
-    def __ge__(self, rhs: object) -> bool:
+    def __ge__(self, rhs: Version) -> bool:
         return rhs <= self
 
 

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -120,7 +120,6 @@ class SemVer(Version):
     default_tag_name = "{version.major}.{version.minor}.{version.patch}{version.prerelease_separator}{version.prerelease}"
 
     def __init__(self, major: int, minor: int, patch: int, prerelease: Tuple[str, ...], build: Tuple[str, ...]):
-        super().__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch
@@ -333,7 +332,6 @@ class CarusoVer(Version):
     default_tag_name = "{version.major}.{version.minor}.{version.patch}{version.prerelease_separator}{version.prerelease}+PI{version.increment}.{version.fix}"
 
     def __init__(self, major: int, minor: int, patch: int, prerelease: Tuple[str, ...], increment: int, fix: int):
-        super().__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -17,13 +17,17 @@ import logging
 import os
 import re
 from typing import (
-        NamedTuple,
-        Optional,
-    )
+    NamedTuple,
+    Optional,
+    Pattern,
+    Union,
+)
 
 from io import (
     open,
 )
+
+from .errors import VersioningError
 
 __all__ = (
     'CarusoVer',
@@ -61,7 +65,7 @@ class SemVer(object):
         * that this relationship is transitive
     """
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'build')
-    default_tag_name = '{version.major}.{version.minor}.{version.patch}'
+    default_tag_name = "{version.major}.{version.minor}.{version.patch}{version.prerelease_separator}{version.prerelease}"
 
     def __init__(self, major, minor, patch, prerelease, build):
         super().__init__()
@@ -83,12 +87,18 @@ class SemVer(object):
     def __repr__(self):
         return '%s(major=%r, minor=%r, patch=%r, prerelease=%r, build=%r)' % ((self.__class__.__name__,) + tuple(self))
 
-    def __str__(self):
+    @property
+    def prerelease_separator(self) -> str:
+        return "-" if self.prerelease else ""
+
+    @property
+    def build_separator(self) -> str:
+        return "+" if self.build else ""
+
+    def __str__(self) -> str:
         ver = '.'.join(str(x) for x in tuple(self)[:3])
-        if self.prerelease:
-            ver += '-' + str(self.prerelease)
-        if self.build:
-            ver += '+' + str(self.build)
+        ver += f"{self.prerelease_separator}{self.prerelease}"
+        ver += f"{self.build_separator}{self.build}"
         return ver
 
     version_re = re.compile(
@@ -266,7 +276,7 @@ class SemVer(object):
 class CarusoVer(object):
     """Caruso-specific versioning policy, overlaps with semantic versioning in syntax but definitely not compatible."""
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'increment', 'fix')
-    default_tag_name = '{version.major}.{version.minor}.{version.patch}+PI{version.increment}.{version.fix}'
+    default_tag_name = "{version.major}.{version.minor}.{version.patch}{version.prerelease_separator}{version.prerelease}+PI{version.increment}.{version.fix}"
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
         super().__init__()
@@ -289,10 +299,13 @@ class CarusoVer(object):
     def __repr__(self):
         return '%s(major=%r, minor=%r, patch=%r, prerelease=%r, increment=%r, fix=%r)' % ((self.__class__.__name__,) + tuple(self))
 
-    def __str__(self):
+    @property
+    def prerelease_separator(self) -> str:
+        return "-" if self.prerelease else ""
+
+    def __str__(self) -> str:
         ver = '.'.join(str(x) for x in tuple(self)[:3])
-        if self.prerelease:
-            ver += '-' + str(self.prerelease)
+        ver += f"{self.prerelease_separator}{self.prerelease}"
         ver += f"+PI{self.increment}.{self.fix}"
         return ver
 
@@ -426,6 +439,39 @@ class CarusoVer(object):
 
     def __ge__(self, rhs):
         return rhs <= self
+
+
+_rejected_hotfix_prefixes = frozenset((
+    "a",
+    "b",
+    "rc",
+    "alpha",
+    "beta",
+))
+
+
+def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Optional[str]:
+    """
+    Extracts a hotfix ID from a hotfix branch name using the given regular expression.
+    """
+    if not isinstance(pat, Pattern):
+        pat = re.compile(pat)
+
+    idx = pat.groupindex.get("id", pat.groupindex.get("ID", 1))
+
+    m = pat.match(branch_name)
+    if not m:
+        return None
+
+    hotfix = m.group(idx)
+
+    if not re.match(r"^[a-zA-Z](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$", hotfix):
+        raise VersioningError(f"Hotfix ID '{hotfix}' is not a valid identifier")
+    prefix = re.split(r"[-.]", hotfix)[0]
+    if re.sub(r"[0-9]+$", "", prefix) in _rejected_hotfix_prefixes:
+        raise VersioningError(f"Hotfix ID '{hotfix}' starts with reserved prefix {prefix}")
+
+    return hotfix
 
 
 _fmts = {

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -23,16 +23,18 @@ class SemVer(object):
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'build')
 
     def __init__(self, major, minor, patch, prerelease, build):
-        assert isinstance(major, int)
-        assert isinstance(minor, int)
-        assert isinstance(patch, int)
-
         super(SemVer, self).__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch
-        self.prerelease = _IdentifierList(prerelease)
-        self.build      = _IdentifierList(build)
+        self.prerelease = prerelease
+        self.build      = build
+
+    def __setattr__(self, name, value):
+        if name in {'major', 'minor', 'patch'}:
+            return super(SemVer, self).__setattr__(name, int(value))
+        elif name in {'prerelease', 'build'}:
+            return super(SemVer, self).__setattr__(name, _IdentifierList(value))
 
     def __iter__(self):
         return iter(getattr(self, attr) for attr in self.__class__.__slots__)

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -264,7 +264,7 @@ class SemVer(object):
         return len(self.prerelease) < len(rhs.prerelease)
 
     def __le__(self, rhs):
-        return self < rhs or self == rhs
+        return self < rhs or tuple(self)[:-1] == tuple(rhs)[:-1]
 
     def __gt__(self, rhs):
         return rhs < self

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -455,8 +455,8 @@ class GitVersion(NamedTuple):
         return not self.dirty and self.commit_count == 0
 
     # NOTE: while this is a regular language, it's one who's captures cannot be described if put in a single regex
-    _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
-    _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')
+    _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')  # type: ignore # avoid complaints about fields starting with underscore
+    _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')         # type: ignore # avoid complaints about fields starting with underscore
 
     @classmethod
     def from_description(cls, description):
@@ -481,7 +481,7 @@ class GitVersion(NamedTuple):
 
         return cls(tag_name=tag_name, dirty=dirty, commit_count=commit_count, commit_hash=abbrev_commit_hash)
 
-    _semver_tag_cleanup = re.compile(r'^[^0-9]+')
+    _semver_tag_cleanup = re.compile(r'^[^0-9]+')  # type: ignore # avoid complaints about fields starting with underscore
 
     def to_version(self, format='semver', dirty_date=None):
         assert format == 'semver', f"Wrong format: {format}"

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -224,6 +224,8 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
 
     assert format == 'semver', "Wrong format: {format}".format(**locals())
     tag_version = SemVer.parse(_git_describe_semver_tag_cleanup.sub('', tag_name))
+    if tag_version is None:
+        return None
 
     if dirty and commit_count is None:
         # Ensure that 'dirty' commits sort before the next non-dirty commit
@@ -238,7 +240,7 @@ def parse_git_describe_version(description, format='semver', dirty_date=None):
         if dirty_date is None:
             dirty_date = datetime.utcnow()
         tag_version.prerelease = tag_version.prerelease + ('dirty', dirty_date.strftime('%Y%m%d%H%M%S'))
-    if abbrev_commit_hash != None:
+    if abbrev_commit_hash is not None:
         tag_version.build = tag_version.build + ('g' + abbrev_commit_hash,)
     return tag_version
 

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,4 +1,5 @@
 from .execution import echo_cmd
+from collections import namedtuple
 import click
 import re
 import subprocess
@@ -11,7 +12,10 @@ except ImportError:
 
 __all__ = (
         'bump_version',
+        'stringify_semver',
     )
+
+SemVer = namedtuple('SemVer', ('major', 'minor', 'patch', 'prerelease', 'build'))
 
 _semver_re = re.compile(r'^(?:version=)?(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?(?:\+(?P<build>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z])*))?$')
 def parse_semver(s):
@@ -33,7 +37,7 @@ def parse_semver(s):
     else:
         build = tuple(build.split('.'))
 
-    return (major, minor, patch, prerelease, build)
+    return SemVer(major, minor, patch, prerelease, build)
 
 def stringify_semver(major, minor, patch, prerelease, build):
     ver = '.'.join(str(x) for x in (major, minor, patch))
@@ -43,7 +47,8 @@ def stringify_semver(major, minor, patch, prerelease, build):
         ver += '+' + '.'.join(build)
     return ver
 
-def bump_version(workspace, file, format='semver', bump='patch', **_):
+_number_re = re.compile(r'^\d+$')
+def bump_version(workspace, file, format='semver', bump='prerelease', **_):
     version = None
     new_content = StringIO()
     with open(file, 'r') as f:
@@ -61,26 +66,49 @@ def bump_version(workspace, file, format='semver', bump='patch', **_):
             if bump:
                 major, minor, patch, prerelease, build = version
 
-                if bump == 'patch':
+                if bump == 'prerelease':
+                    increment_idx = None
+                    for idx, elem in reversed(list(enumerate(prerelease))):
+                        if _number_re.match(elem):
+                            increment_idx = idx
+                            break
+                    if increment_idx is not None:
+                        prerelease = (
+                                prerelease[:increment_idx]
+                              + (str(int(prerelease[increment_idx]) + 1),)
+                              + prerelease[increment_idx + 1:]
+                            )
+                    else:
+                        prerelease = prerelease + ('1',)
+
+                    # When bumping the prerelease tag the build tags need to be dropped always
+                    build = ()
+                elif bump == 'patch':
                     if not prerelease:
                         patch += 1
+
+                    # When bumping version the prerelease and build tags need to be dropped always
+                    prerelease, build = (), ()
                 elif bump == 'minor':
                     if not (prerelease and patch == 0):
                         minor += 1
                     patch = 0
+
+                    # When bumping version the prerelease and build tags need to be dropped always
+                    prerelease, build = (), ()
                 elif bump == 'major':
                     if not (prerelease and minor == 0 and patch == 0):
                         major += 1
                     major = 0
                     minor = 0
+
+                    # When bumping version the prerelease and build tags need to be dropped always
+                    prerelease, build = (), ()
                 else:
                     click.echo("Invalid version bumping target: {bump}".format(**locals()), err=True)
                     sys.exit(1)
 
-                # When bumping the prerelease tags need to be dropped always
-                prerelease, build = (), ()
-
-                version = (major, minor, patch, prerelease, build)
+                version = SemVer(major, minor, patch, prerelease, build)
 
                 # Replace version in source line
                 m = _semver_re.match(l)
@@ -93,4 +121,4 @@ def bump_version(workspace, file, format='semver', bump='patch', **_):
             f.write(new_content.getvalue())
         echo_cmd(subprocess.check_call, ('git', 'add', file), cwd=workspace)
 
-    return (stringify_semver(*version) if version is not None else version)
+    return version

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -200,6 +200,9 @@ class SemVer(object):
             return self.next_patch()
         return self
 
+    def pure_version(self):
+        return SemVer(self.major, self.minor, self.patch, self.prerelease, ())
+
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):
             return NotImplemented
@@ -370,6 +373,9 @@ class CarusoVer(object):
 
     def next_version_for_commits(self, commits):
         raise NotImplementedError
+
+    def pure_version(self):
+        return self
 
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -244,7 +244,7 @@ class SemVer(object):
 class CarusoVer(object):
     """Caruso-specific versioning policy, overlaps with semantic versioning in syntax but definitely not compatible."""
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'increment', 'fix')
-    default_tag_name = '{version.major}{version.minor}{version.patch}+PI{version.increment}.{version.fix}'
+    default_tag_name = '{version.major}.{version.minor}.{version.patch}+PI{version.increment}.{version.fix}'
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
         super(CarusoVer, self).__init__()

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -70,6 +70,68 @@ class SemVer(object):
 
         return cls(major, minor, patch, prerelease, build)
 
+    def __eq__(self, rhs):
+        if not isinstance(rhs, self.__class__):
+            return NotImplemented
+        if tuple(self)[:4] != tuple(rhs)[:4]:
+            return False
+        if self.build != rhs.build:
+            return NotImplemented
+        return True
+
+    def __ne__(self, rhs):
+        if not isinstance(rhs, self.__class__):
+            return NotImplemented
+        if tuple(self)[:4] != tuple(rhs)[:4]:
+            return True
+        if self.build != rhs.build:
+            return NotImplemented
+        return False
+
+    def __lt__(self, rhs):
+        if tuple(self)[:3] < tuple(rhs)[:3]:
+            return True
+        if tuple(self)[:3] != tuple(rhs)[:3]:
+            return False
+
+        if self.prerelease and not rhs.prerelease:
+            # Having a prerelease sorts before not having one
+            return True
+        elif not self.prerelease:
+            return False
+
+        assert self.prerelease and rhs.prerelease
+
+        for a, b in zip(self.prerelease, rhs.prerelease):
+            try:
+                a = int(a)
+            except ValueError:
+                pass
+            try:
+                b = int(b)
+            except ValueError:
+                pass
+            if isinstance(a, int) and not isinstance(b, int):
+                # Numeric identifiers sort before non-numeric ones
+                return True
+            elif isinstance(a, int) != isinstance(b, int):
+                return False
+            if a < b:
+                return True
+            elif b < a:
+                return False
+
+        return len(self.prerelease) < len(rhs.prerelease)
+
+    def __le__(self, rhs):
+        return self < rhs or self == rhs
+
+    def __gt__(self, rhs):
+        return rhs < self
+
+    def __ge__(self, rhs):
+        return rhs <= self
+
 _number_re = re.compile(r'^\d+$')
 def bump_version(workspace, file, format='semver', bump='prerelease'):
     version = None

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -200,9 +200,6 @@ class SemVer(object):
             return self.next_patch()
         return self
 
-    def pure_version(self):
-        return SemVer(self.major, self.minor, self.patch, self.prerelease, ())
-
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):
             return NotImplemented
@@ -373,9 +370,6 @@ class CarusoVer(object):
 
     def next_version_for_commits(self, commits):
         raise NotImplementedError
-
-    def pure_version(self):
-        return self
 
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -478,7 +478,7 @@ def replace_version(fname, new_version, encoding=None, outfile=None):
                 if m:
                     line = line[:m.start(1)] + str(new_version) + line[m.end(m.lastgroup)]
                 out.write(line)
-    except:  # ignore E722 here: we re-raise, so it's not a problem
+    except:  # noqa: E722: we re-raise, so it's not a problem
         if outfile is None:
             out.close()
             os.remove(fname + '.tmp')

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -87,7 +87,7 @@ class Version(Protocol):
     @classmethod
     def parse(cls, s: str) -> Optional["Version"]: ...
 
-    def next_prerelease(self, seed: Optional[Stringable] = None) -> "Version": ...
+    def next_prerelease(self, seed: Union[None, str, Iterable[Stringable]] = None) -> "Version": ...
     def next_version(self, bump: Any, **kwargs: Any) -> "Version": ...
     def next_version_for_commits(self, commits: Iterable[TBD]) -> "Version": ...
     def without_meta(self) -> "Version": ...
@@ -208,7 +208,7 @@ class SemVer(Version):
         return SemVer(self.major, self.minor, self.patch + 1, (), ())
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
-    def next_prerelease(self, seed: Optional[Stringable] = None) -> "SemVer":  # noqa: E301 'expected 1 blank line'
+    def next_prerelease(self, seed: Union[None, str, Iterable[Stringable]] = None) -> "SemVer":  # noqa: E301 'expected 1 blank line'
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
             if isinstance(seed, str):
@@ -405,7 +405,7 @@ class CarusoVer(Version):
         return CarusoVer(self.major, self.minor, self.patch, (), self.increment, self.fix + 1)
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
-    def next_prerelease(self, seed: Optional[Stringable] = None) -> "CarusoVer":  # noqa: E301 'expected 1 blank line'
+    def next_prerelease(self, seed: Union[None, str, Iterable[Stringable]] = None) -> "CarusoVer":  # noqa: E301 'expected 1 blank line'
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
             if isinstance(seed, str):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -244,7 +244,7 @@ class SemVer(object):
 class CarusoVer(object):
     """Caruso-specific versioning policy, overlaps with semantic versioning in syntax but definitely not compatible."""
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'increment', 'fix')
-    default_tag_name = '{version}'
+    default_tag_name = '{version.major}{version.minor}{version.patch}+PI{version.increment}.{version.fix}'
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
         super(CarusoVer, self).__init__()

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -20,6 +20,7 @@ from typing import (
     NamedTuple,
     Optional,
     Pattern,
+    Tuple,
     Union,
 )
 
@@ -457,12 +458,12 @@ _rejected_hotfix_prefixes = frozenset((
 ))
 
 
-def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Optional[str]:
+def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Tuple[str, ...]:
     """
     Extracts a hotfix ID from a hotfix branch name using the given regular expression.
     """
     if branch_name is None:
-        return None
+        return ()
 
     if not isinstance(pat, Pattern):
         pat = re.compile(pat)
@@ -471,17 +472,17 @@ def hotfix_id(pat: Union[str, Pattern], branch_name: Optional[str]) -> Optional[
 
     m = pat.match(branch_name)
     if not m:
-        return None
+        return ()
 
     hotfix = m.group(idx)
 
-    if not re.match(r"^[a-zA-Z](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$", hotfix):
+    if not re.match(r"^[a-zA-Z](?:[-.a-zA-Z0-9]*[a-zA-Z0-9])?$", hotfix):
         raise VersioningError(f"Hotfix ID '{hotfix}' is not a valid identifier")
     prefix = re.split(r"[-.]", hotfix)[0]
     if re.sub(r"[0-9]+$", "", prefix) in _rejected_hotfix_prefixes:
         raise VersioningError(f"Hotfix ID '{hotfix}' starts with reserved prefix {prefix}")
 
-    return hotfix
+    return tuple(hotfix.split("."))
 
 
 _fmts = {

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -16,6 +16,10 @@ from datetime import datetime
 import logging
 import os
 import re
+from typing import (
+        NamedTuple,
+        Optional,
+    )
 
 from io import (
     open,
@@ -23,8 +27,8 @@ from io import (
 
 __all__ = (
     'CarusoVer',
+    'GitVersion',
     'SemVer',
-    'parse_git_describe_version',
     'read_version',
     'replace_version',
 )
@@ -440,52 +444,64 @@ def read_version(fname, format='semver', encoding=None):
                 return version
 
 
-# NOTE: while this is a regular language, it's one who's captures cannot be described if put in a single regex
-_git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
-_git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')
-_git_describe_semver_tag_cleanup = re.compile(r'^[^0-9]+')
-def parse_git_describe_version(description, format='semver', dirty_date=None):  # noqa: E302 'expected 2 blank lines'
-    dirty = description.endswith('-dirty')
-    if dirty:
-        description = description[:-len('-dirty')]
+class GitVersion(NamedTuple):
+    tag_name     : str
+    dirty        : bool = False
+    commit_count : Optional[int] = None
+    commit_hash  : Optional[str] = None
 
-    abbrev_commit_hash = None
-    commit_match = _git_describe_commit_re.match(description)
-    if commit_match:
-        description, abbrev_commit_hash = commit_match.groups()
-        if description is None:
-            description = ''
+    # NOTE: while this is a regular language, it's one who's captures cannot be described if put in a single regex
+    _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
+    _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')
 
-    commit_count = None
-    count_match = _git_describe_distance_re.match(description)
-    if count_match:
-        commit_count = int(count_match.group(2))
-        tag_name = count_match.group(1)
-    else:
-        tag_name = description
+    @classmethod
+    def from_description(cls, description):
+        dirty = description.endswith('-dirty')
+        if dirty:
+            description = description[:-len('-dirty')]
 
-    assert format == 'semver', f"Wrong format: {format}"
-    version_part = _git_describe_semver_tag_cleanup.sub('', tag_name)
-    tag_version = SemVer.parse(version_part)
-    if tag_version is None:
-        log.warning('Failed to parse version string %r as %s', version_part, format)
-        return None
+        abbrev_commit_hash = None
+        commit_match = cls._git_describe_commit_re.match(description)
+        if commit_match:
+            description, abbrev_commit_hash = commit_match.groups()
+            if description is None:
+                description = ''
 
-    if (commit_count or dirty) and not tag_version.prerelease:
-        tag_version = tag_version.next_patch()
+        commit_count = None
+        count_match = cls._git_describe_distance_re.match(description)
+        if count_match:
+            commit_count = int(count_match.group(2))
+            tag_name = count_match.group(1)
+        else:
+            tag_name = description
 
-    if commit_count:
-        tag_version.prerelease = tag_version.prerelease + (str(commit_count),)
-    if dirty:
-        if dirty_date is None:
-            dirty_date = datetime.utcnow()
-        if not commit_count:
-            # Ensure that 'dirty' commits sort before the next non-dirty commit
-            tag_version.prerelease = tag_version.prerelease + ('0',)
-        tag_version.prerelease = tag_version.prerelease + ('dirty', dirty_date.strftime('%Y%m%d%H%M%S'))
-    if abbrev_commit_hash is not None:
-        tag_version.build = tag_version.build + ('g' + abbrev_commit_hash,)
-    return tag_version
+        return cls(tag_name=tag_name, dirty=dirty, commit_count=commit_count, commit_hash=abbrev_commit_hash)
+
+    _semver_tag_cleanup = re.compile(r'^[^0-9]+')
+
+    def to_version(self, format='semver', dirty_date=None):
+        assert format == 'semver', f"Wrong format: {format}"
+        version_part = self._semver_tag_cleanup.sub('', self.tag_name)
+        tag_version = SemVer.parse(version_part)
+        if tag_version is None:
+            log.warning('Failed to parse version string %r as %s', version_part, format)
+            return None
+
+        if (self.commit_count or self.dirty) and not tag_version.prerelease:
+            tag_version = tag_version.next_patch()
+
+        if self.commit_count:
+            tag_version.prerelease = tag_version.prerelease + (str(self.commit_count),)
+        if self.dirty:
+            if dirty_date is None:
+                dirty_date = datetime.utcnow()
+            if not self.commit_count:
+                # Ensure that 'dirty' commits sort before the next non-dirty commit
+                tag_version.prerelease = tag_version.prerelease + ('0',)
+            tag_version.prerelease = tag_version.prerelease + ('dirty', dirty_date.strftime('%Y%m%d%H%M%S'))
+        if self.commit_hash is not None:
+            tag_version.build = tag_version.build + ('g' + self.commit_hash,)
+        return tag_version
 
 
 def replace_version(fname, new_version, encoding=None, outfile=None):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -81,13 +81,16 @@ class Version(Protocol):
     patch: int
     prerelease: Tuple[str, ...]
 
+    # fmt: off
     def __iter__(self) -> Iterator[Any]: ...
 
     @classmethod
     def parse(cls, s: str) -> Optional["Version"]: ...
 
+    def next_prerelease(self, seed: Optional[Stringable] = None) -> "Version": ...
     def next_version(self, bump: Any, **kwargs: Any) -> "Version": ...
     def next_version_for_commits(self, commits: Iterable[TBD]) -> "Version": ...
+    def without_meta(self) -> "Version": ...
 
     def __eq__(self, rhs: Any) -> bool: ...
     def __ne__(self, rhs: Any) -> bool: ...
@@ -95,6 +98,7 @@ class Version(Protocol):
     def __le__(self, rhs: "Version") -> bool: ...
     def __gt__(self, rhs: "Version") -> bool: ...
     def __ge__(self, rhs: "Version") -> bool: ...
+    # fmt: on
 
 
 class SemVer(Version):
@@ -258,6 +262,9 @@ class SemVer(Version):
         elif has_fix:
             return self.next_patch()
         return self
+
+    def without_meta(self) -> "SemVer":
+        return SemVer(self.major, self.minor, self.patch, self.prerelease, ())
 
     def __eq__(self, rhs: object) -> bool:
         if not isinstance(rhs, self.__class__):
@@ -437,6 +444,9 @@ class CarusoVer(Version):
 
     def next_version_for_commits(self, commits: Iterable[TBD]) -> NoReturn:
         raise NotImplementedError
+
+    def without_meta(self) -> "CarusoVer":
+        return self
 
     def __eq__(self, rhs: object) -> bool:
         if not isinstance(rhs, self.__class__):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 - 2019 TomTom N.V. (https://tomtom.com)
+# Copyright (c) 2018 - 2020 TomTom N.V. (https://tomtom.com)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ class SemVer(object):
 
     version_re = re.compile(
         r'^(?:version=)?'
-      + r'(?P<major>0|[1-9][0-9]*)'
+      + r'(?P<major>0|[1-9][0-9]*)'                                  # noqa: E131
       + r'\.(?P<minor>0|[1-9][0-9]*)'
       + r'\.(?P<patch>0|[1-9][0-9]*)'
       + r'(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z]+)*))?'
@@ -141,7 +141,7 @@ class SemVer(object):
         return SemVer(self.major, self.minor, self.patch + 1, (), ())
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
-    def next_prerelease(self, seed=None):
+    def next_prerelease(self, seed=None):  # noqa: E301 'expected 1 blank line'
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
             if isinstance(seed, str):
@@ -164,7 +164,7 @@ class SemVer(object):
         # Increment only the specified identifier
         prerelease = (
             self.prerelease[:increment_idx]
-          + (str(int(self.prerelease[increment_idx]) + 1),)
+          + (str(int(self.prerelease[increment_idx]) + 1),)  # noqa: E131
           + self.prerelease[increment_idx + 1:]
         )
         return SemVer(self.major, self.minor, self.patch, prerelease, ())
@@ -175,9 +175,9 @@ class SemVer(object):
             kwargs['seed'] = kwargs.pop('prerelease_seed')
         return {
             'prerelease': self.next_prerelease,
-            'patch':      self.next_patch,
-            'minor':      self.next_minor,
-            'major':      self.next_major,
+            'patch'     : self.next_patch,
+            'minor'     : self.next_minor,
+            'major'     : self.next_major,
         }[bump](*args, **kwargs)
 
     def next_version_for_commits(self, commits):
@@ -294,7 +294,7 @@ class CarusoVer(object):
 
     version_re = re.compile(
         r'^(?:version=)?'
-      + r'(?P<major>0|[1-9][0-9]*)'
+      + r'(?P<major>0|[1-9][0-9]*)'                                  # noqa: E131
       + r'\.(?P<minor>0|[1-9][0-9]*)'
       + r'\.(?P<patch>0|[1-9][0-9]*)'
       + r'(?:-(?P<prerelease>[-0-9a-zA-Z]+(?:\.[-0-9a-zA-Z]+)*))?'
@@ -327,7 +327,7 @@ class CarusoVer(object):
         return CarusoVer(self.major, self.minor, self.patch, (), self.increment, self.fix + 1)
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
-    def next_prerelease(self, seed=None):
+    def next_prerelease(self, seed=None):  # noqa: E301 'expected 1 blank line'
         # Special case for if we don't have a prerelease: bump patch and seed prerelease
         if not self.prerelease:
             if isinstance(seed, str):
@@ -350,7 +350,7 @@ class CarusoVer(object):
         # Increment only the specified identifier
         prerelease = (
             self.prerelease[:increment_idx]
-          + (str(int(self.prerelease[increment_idx]) + 1),)
+          + (str(int(self.prerelease[increment_idx]) + 1),)  # noqa: E131
           + self.prerelease[increment_idx + 1:]
         )
         return CarusoVer(self.major, self.minor, self.patch, prerelease, self.increment, self.fix)
@@ -361,7 +361,7 @@ class CarusoVer(object):
             kwargs['seed'] = kwargs.pop('prerelease_seed')
         return {
             'prerelease': self.next_prerelease,
-            'fix':        self.next_fix,
+            'fix'       : self.next_fix,
         }[bump](*args, **kwargs)
 
     def next_version_for_commits(self, commits):
@@ -444,7 +444,7 @@ def read_version(fname, format='semver', encoding=None):
 _git_describe_commit_re = re.compile(r'^(?:(.*)-g)?([0-9a-f]+)$')
 _git_describe_distance_re = re.compile(r'^(.*)-([0-9]+)$')
 _git_describe_semver_tag_cleanup = re.compile(r'^[^0-9]+')
-def parse_git_describe_version(description, format='semver', dirty_date=None):
+def parse_git_describe_version(description, format='semver', dirty_date=None):  # noqa: E302 'expected 2 blank lines'
     dirty = description.endswith('-dirty')
     if dirty:
         description = description[:-len('-dirty')]

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -179,14 +179,19 @@ class SemVer(object):
 
     def next_version_for_commits(self, commits):
         has_new_feature = False
+        has_fix = False
         for commit in commits:
             if commit.has_breaking_change():
                 return self.next_major()
             if commit.has_new_feature():
                 has_new_feature = True
+            if commit.has_fix():
+                has_fix = True
         if has_new_feature:
             return self.next_minor()
-        return self.next_patch()
+        elif has_fix:
+            return self.next_patch()
+        return self
 
     def __eq__(self, rhs):
         if not isinstance(rhs, self.__class__):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2018 - 2019 TomTom N.V. (https://tomtom.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime
 import re
 

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -55,6 +55,7 @@ class SemVer(object):
         * that this relationship is transitive
     """
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'build')
+    default_tag_name = '{version.major}.{version.minor}.{version.patch}'
 
     def __init__(self, major, minor, patch, prerelease, build):
         super(SemVer, self).__init__()
@@ -243,6 +244,7 @@ class SemVer(object):
 class CarusoVer(object):
     """Caruso-specific versioning policy, overlaps with semantic versioning in syntax but definitely not compatible."""
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'increment', 'fix')
+    default_tag_name = '{version}'
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
         super(CarusoVer, self).__init__()

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -479,7 +479,7 @@ def replace_version(fname, new_version, encoding=None, outfile=None):
                 # Replace version in source line
                 m = new_version.version_re.match(line)
                 if m:
-                    line = line[:m.start(1)] + str(new_version) + line[m.end(m.lastgroup)]
+                    line = line[:m.start(1)] + str(new_version) + line[m.end(m.lastgroup):]
                 out.write(line)
     except:  # noqa: E722: we re-raise, so it's not a problem
         if temp is not None:

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -108,6 +108,10 @@ class SemVer(object):
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
     def next_prerelease(self):
+        # Special case for if we don't have a prerelease: bump patch and seed prerelease
+        if not self.prerelease:
+            return SemVer(self.major, self.minor, self.patch + 1, ('1',), ())
+
         # Find least significant numeric identifier to increment
         increment_idx = None
         for idx, elem in reversed(list(enumerate(self.prerelease))):

--- a/commisery/versioning.py
+++ b/commisery/versioning.py
@@ -22,7 +22,7 @@ from io import (
 )
 
 __all__ = (
-    'CarVer',
+    'CarusoVer',
     'SemVer',
     'parse_git_describe_version',
     'read_version',
@@ -240,12 +240,12 @@ class SemVer(object):
         return rhs <= self
 
 
-class CarVer(object):
+class CarusoVer(object):
     """Caruso-specific versioning policy, overlaps with semantic versioning in syntax but definitely not compatible."""
     __slots__ = ('major', 'minor', 'patch', 'prerelease', 'increment', 'fix')
 
     def __init__(self, major, minor, patch, prerelease, increment, fix):
-        super(CarVer, self).__init__()
+        super(CarusoVer, self).__init__()
         self.major      = major
         self.minor      = minor
         self.patch      = patch
@@ -255,9 +255,9 @@ class CarVer(object):
 
     def __setattr__(self, name, value):
         if name in {'major', 'minor', 'patch', 'increment', 'fix'}:
-            return super(CarVer, self).__setattr__(name, int(value))
+            return super(CarusoVer, self).__setattr__(name, int(value))
         elif name in {'prerelease'}:
-            return super(CarVer, self).__setattr__(name, _IdentifierList(value))
+            return super(CarusoVer, self).__setattr__(name, _IdentifierList(value))
 
     def __iter__(self):
         return iter(getattr(self, attr) for attr in self.__class__.__slots__)
@@ -302,9 +302,9 @@ class CarVer(object):
     def next_fix(self):
         if self.prerelease:
             # Just strip pre-release
-            return CarVer(self.major, self.minor, self.patch, (), self.increment, self.fix)
+            return CarusoVer(self.major, self.minor, self.patch, (), self.increment, self.fix)
 
-        return CarVer(self.major, self.minor, self.patch, (), self.increment, self.fix + 1)
+        return CarusoVer(self.major, self.minor, self.patch, (), self.increment, self.fix + 1)
 
     _number_re = re.compile(r'^(?:[1-9][0-9]*|0)$')
     def next_prerelease(self, seed=None):
@@ -316,7 +316,7 @@ class CarVer(object):
                 seed = ('1',)
             seed = tuple(str(i) for i in seed)
 
-            return CarVer(self.major, self.minor, self.patch, seed, self.increment, self.fix + 1)
+            return CarusoVer(self.major, self.minor, self.patch, seed, self.increment, self.fix + 1)
 
         # Find least significant numeric identifier to increment
         increment_idx = None
@@ -325,7 +325,7 @@ class CarVer(object):
                 increment_idx = idx
                 break
         if increment_idx is None:
-            return CarVer(self.major, self.minor, self.patch, self.prerelease + ('1',), self.increment, self.fix)
+            return CarusoVer(self.major, self.minor, self.patch, self.prerelease + ('1',), self.increment, self.fix)
 
         # Increment only the specified identifier
         prerelease = (
@@ -333,7 +333,7 @@ class CarVer(object):
           + (str(int(self.prerelease[increment_idx]) + 1),)
           + self.prerelease[increment_idx + 1:]
         )
-        return CarVer(self.major, self.minor, self.patch, prerelease, self.increment, self.fix)
+        return CarusoVer(self.major, self.minor, self.patch, prerelease, self.increment, self.fix)
 
     def next_version(self, bump='prerelease', *args, **kwargs):
         if bump == 'prerelease' and 'prerelease_seed' in kwargs:
@@ -403,7 +403,7 @@ class CarVer(object):
 
 _fmts = {
     'semver': SemVer,
-    'carver': CarVer,
+    'carver': CarusoVer,
 }
 
 


### PR DESCRIPTION
In the interest of code re-use and avoiding needing duplication, we
should move (most of) the versioning module from Hopic to Commisery.

Since Hopic already uses the `CommitMessage` functionality in
Commisery, this move should be fairly trivial.

This PR is mostly a commit history import.
One commit is mine: 4d165f8b