### PR TITLE
feat: add `next-version` subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Options:
   --help                          Show this message and exit.
 
 Commands:
-  check     Checks whether commit messages adhere to the Convention Commits...
-  commit    Creates a conventional commit
-  overview  Lists the accepted Conventional Commit tags and Rules (incl.
+  check         Checks whether commit messages adhere to the Convention Commits...
+  commit        Creates a conventional commit
+  next-version  Provides the next version based on Conventional Commit...
+  overview      Lists the accepted Conventional Commit tags and Rules (incl.
 ```
 
 ### Create and Commit a new Conventional Commit
@@ -99,9 +100,40 @@ $ cm check :/'refactor'..HEAD
 $ cm check 2fff3d8..8c33495
 ```
 
-The exit code of will be non-zero *if and only if* it found errors in the given commit message(s).
+Commisery's exit code will be non-zero if it found errors in the given commit message(s).
 
 > **NOTE**: *in order to remain backwards compatible, the command `commisery-verify-msg` can be used as alternative for `cm check`*
+
+### Next version for commits
+
+Commisery can determine the next version, based on Conventional Commit messages since the latest tag.
+The bumping behavior is as follows:
+ - breaking changes bump major
+ - `feat` types bump minor
+ - `fix` types bump patch
+
+If no bumping commits are found since the latest tag, `cm next-version` will return an empty string on standard output.
+
+For example:
+```
+$ git log --oneline --decorate-refs tags
+3e3eb7b feat: add even better component Y
+1021f70 test(componentX): add unit tests
+7177f78 feat: add component X
+227a58f (tag: 1.0.0) feat: initial implementation
+$ cm next-version
+1.1.0
+```
+
+The next version (if any) will be printed to standard output, while any informational or error messages will be printed to standard error.
+
+A very basic example of bumping logic that can be used in CI systems:
+```sh
+BUMPED_VERSION=`cm next-version`
+if [ ! -z "$BUMPED_VERSION" ]; then
+  git tag $BUMPED_VERSION
+fi
+```
 
 ### (Pre-) Commit hook
 

--- a/commisery/cli/__init__.py
+++ b/commisery/cli/__init__.py
@@ -71,9 +71,7 @@ def main(ctx, config, tags, max_subject_length, disable):
     ctx.ensure_object(dict)
     config = Configuration.from_yaml(config)
     if tags:
-        config.tags = {
-            key: "No description available (provided by CLI)" for key in tags.split(",")
-        }
+        config.tags = {key: "No description available (provided by CLI)" for key in tags.split(",")}
 
     if max_subject_length:
         config.max_subject_length = max_subject_length
@@ -102,7 +100,7 @@ def overview(ctx):
     print("Commisery Validation rules")
     print("--------------------------")
     print(
-        "[\033[92mo\033[0m]: \033[90mrule is enabled\033[0m, [\033[91mx\033[0m]: \033[90mrule has been disabled\033[0m"
+        "[\033[92mo\033[0m]: \033[90mrule is enabled\033[0m, [\033[91mx\033[0m]: \033[90mrule has been disabled\033[0m"  # pylint: disable=line-too-long
     )
     print()
     for rule, value in config.rules.items():
@@ -115,7 +113,7 @@ def overview(ctx):
 @click.option(
     "-t",
     "--type",
-    type=click.Choice(DEFAULT_ACCEPTED_TAGS),
+    type=click.Choice(tuple(DEFAULT_ACCEPTED_TAGS.keys())),
     help="Conventional Commit type",
 )
 @click.option("-s", "--scope", help="Conventional commit scope")
@@ -131,9 +129,7 @@ def commit(ctx, type, scope, description, breaking_change):
         questions = []
 
         if not type:
-            tag_choices = [
-                f"{tag}: {description}" for tag, description in config.tags.items()
-            ]
+            tag_choices = [f"{tag}: {description}" for tag, description in config.tags.items()]
 
             questions.append(
                 inquirer.Choice(
@@ -145,15 +141,11 @@ def commit(ctx, type, scope, description, breaking_change):
             )
 
         if not scope:
-            questions.append(
-                inquirer.Input(name="scope", message="Specify the scope (Optional)")
-            )
+            questions.append(inquirer.Input(name="scope", message="Specify the scope (Optional)"))
 
         if not description:
             questions.append(
-                inquirer.Input(
-                    name="description", message="Specify the subject of the commit"
-                )
+                inquirer.Input(name="description", message="Specify the subject of the commit")
             )
 
         questions.append(
@@ -241,9 +233,7 @@ def check(ctx, target):
             not re.match(r"^[0-9a-fA-F]{40}$", target_str)
             and not os.path.exists(target_str)
             and len(
-                subprocess.check_output(
-                    ("git", "rev-parse") + target, stderr=subprocess.DEVNULL
-                )
+                subprocess.check_output(("git", "rev-parse") + target, stderr=subprocess.DEVNULL)
                 .decode(encoding="UTF-8")
                 .splitlines()
             )

--- a/commisery/config.py
+++ b/commisery/config.py
@@ -62,6 +62,7 @@ class Configuration:
     max_subject_length: int = 80
     _tags: Mapping = field(default_factory=lambda: DEFAULT_ACCEPTED_TAGS)
     rules: Mapping = field(default_factory=lambda: get_default_rules())
+    silent: bool = False
 
     def __post_init__(self):
         """Post initializer"""

--- a/commisery/rules.py
+++ b/commisery/rules.py
@@ -506,9 +506,10 @@ def validate_commit_message_rule(
         if config.rules[rule].get("enabled"):
             get_default_rules()[rule].get("obj")(message, config)
     except logging.Error as err:
-        err.message = f"[{rule}] {err.message}"
-        err.file_path = message.hexsha
-        err.report()
+        if not config.silent:
+            err.message = f"[{rule}] {err.message}"
+            err.file_path = message.hexsha
+            err.report()
         return 1
 
     return 0

--- a/commisery/test/conftest.py
+++ b/commisery/test/conftest.py
@@ -27,9 +27,11 @@ except ImportError:
     import importlib_metadata as metadata
 
 
-commisery_range_cli = [
-    ep for ep in metadata.entry_points()["console_scripts"] if ep.name == "cm"
-][0].load()
+if sys.version_info >= (3, 8):
+    _eps = metadata.entry_points().select(group="console_scripts")
+else:
+    _eps = metadata.entry_points()["console_scripts"]
+commisery_range_cli = [ep for ep in _eps if ep.name == "cm"][0].load()
 
 
 @pytest.fixture()

--- a/commisery/test/conftest.py
+++ b/commisery/test/conftest.py
@@ -19,6 +19,7 @@ import types
 import git
 import pytest
 from click.testing import CliRunner
+from .util import CommitAndTag
 
 try:
     # Python >= 3.8
@@ -36,37 +37,57 @@ commisery_range_cli = [ep for ep in _eps if ep.name == "cm"][0].load()
 
 @pytest.fixture()
 def commisery_cli():
-    def _cli(commit_messages, rev_range=None, with_tags=(), verbose=True):
+    def _cli(
+        commit_messages,
+        rev_range=None,
+        with_tags=(),
+        verbose=True,
+        command="check",
+    ):
         runner = CliRunner(mix_stderr=False)
         with runner.isolated_filesystem():
             with git.Repo.init() as repo:
                 if isinstance(commit_messages, types.GeneratorType):
                     commit_messages = list(commit_messages)
-                for msg in commit_messages:
-                    repo.index.commit(msg, author=git.Actor("Bob", "bob@tester.org>"))
+                for commit in commit_messages:
+                    if isinstance(commit, CommitAndTag):
+                        message = commit.message
+                        tag = commit.tag
+                    else:
+                        message = commit
+                        tag = None
+                    with open("test_file", "a") as f:
+                        f.write(".")
+                    repo.index.add(("test_file",))
 
-                if rev_range is None:
-                    # We'll check all messages if revision range is not provided
-                    rev_range = ("HEAD",)
+                    assert isinstance(message, str)
+                    repo.index.commit(message, author=git.Actor("Bob", "bob@tester.org>"))
 
-                assert isinstance(rev_range, collections.abc.Sequence)
+                    if tag is not None:
+                        assert isinstance(tag, str)
+                        repo.create_tag(path=tag, ref="HEAD")
 
                 args = ["-v", "DEBUG"] if verbose else []
                 if with_tags:
                     args.extend(("-t", ",".join(with_tags)))
-                args.append("check")
-                args.extend(rev_range)
+                args.append(command)
+
+                if rev_range is None:
+                    # We'll check all messages if revision range is not provided by the test
+                    rev_range = ("HEAD",)
+                assert isinstance(rev_range, collections.abc.Sequence)
+
+                # Empty string means default/not-defined
+                if rev_range != "":
+                    args.extend(rev_range)
 
                 result = runner.invoke(commisery_range_cli, args=args, color=True)
-
                 if result.stdout_bytes:
                     print(result.stdout, end="")
                 if result.stderr_bytes:
                     print(result.stderr, end="", file=sys.stderr)
 
-                if result.exception is not None and not isinstance(
-                    result.exception, SystemExit
-                ):
+                if result.exception is not None and not isinstance(result.exception, SystemExit):
                     raise result.exception
 
                 return result

--- a/commisery/test/test_hopic.py
+++ b/commisery/test/test_hopic.py
@@ -37,9 +37,12 @@ try:
         (int(x) if re.match("^[0-9]+$", x) else x)
         for x in metadata.version("hopic").split(".")
     )
-    hopic_cli = [
-        ep for ep in metadata.entry_points()["console_scripts"] if ep.name == "hopic"
-    ][0].load()
+
+    if sys.version_info >= (3, 8):
+        _eps = metadata.entry_points().select(group="console_scripts")
+    else:
+        _eps = metadata.entry_points()["console_scripts"]
+    hopic_cli = [ep for ep in _eps if ep.name == "hopic"][0].load()
     from click.testing import CliRunner
     import git
 except metadata.PackageNotFoundError:

--- a/commisery/test/test_next_version.py
+++ b/commisery/test/test_next_version.py
@@ -1,0 +1,246 @@
+# Copyrighy (c) 2020 - 2022 TomTom N.V. (https://tomtom.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import pytest
+
+from .util import CommitAndTag
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    ("commits", "version", "exitcode"),
+    (
+        # Doubles for fix, feat and breaking change
+        (
+            (
+                CommitAndTag("docs: test", "1.0.1"),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("fix: test", None),
+            ),
+            "1.0.2",
+            0,
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "10.0.1"),
+                CommitAndTag("feat: test", None),
+                CommitAndTag("feat: test", None),
+            ),
+            "10.1.0",
+            0,
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "1.2.3"),
+                CommitAndTag("feat!: test", None),
+            ),
+            "2.0.0",
+            0,
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "1.2.3"),
+                CommitAndTag("feat: test\n\nBody\n\nBREAKING CHANGE: Test", None),
+                CommitAndTag("feat!: test", None),
+            ),
+            "2.0.0",
+            0,
+        ),
+        # Priority / order
+        (
+            (
+                CommitAndTag("docs: test", "0.0.1"),
+                CommitAndTag("feat: test", None),
+                CommitAndTag("ci: test", None),
+                CommitAndTag("fix: test", None),
+            ),
+            "0.1.0",
+            0,
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "0.0.1"),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("ci: test", None),
+            ),
+            "0.0.2",
+            0,
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "0.0.1"),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("ci: test", None),
+                CommitAndTag("feat: test", None),
+            ),
+            "0.1.0",
+            0,
+        ),
+        # No bump
+        (
+            (
+                CommitAndTag("docs: test", "0.0.1"),
+                CommitAndTag("ci: test", None),
+            ),
+            "",
+            2,
+        ),
+        # No commits
+        (
+            (CommitAndTag("feat: test", "0.0.1"),),
+            "",
+            2,
+        ),
+        # No conventional commits
+        (
+            (
+                CommitAndTag("initial commit", "0.0.1"),
+                CommitAndTag("fix something", None),
+            ),
+            "",
+            2,
+        ),
+        # Mix conventional/non-conventional
+        (
+            (
+                CommitAndTag("initial commit", "0.0.1"),
+                CommitAndTag("fix something", None),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("fix: add missing header `banana.h`", None),
+            ),
+            "0.0.2",
+            0,
+        ),
+    ),
+)
+def test_next_version_generic(commisery_cli, commits, version, exitcode):
+    result = commisery_cli(commit_messages=commits, command="next-version", rev_range="")
+
+    assert result.stdout.strip() == version
+    assert result.exit_code == exitcode
+
+
+@pytest.mark.parametrize(
+    ("commits", "version", "exitcode", "target"),
+    (
+        (
+            (
+                CommitAndTag("docs: test", "1.0.1"),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("feat: test", None),
+            ),
+            "1.0.2",
+            0,
+            ("HEAD^",),
+        ),
+        (
+            (
+                CommitAndTag("docs: test", "1.0.1"),
+                CommitAndTag("fix: test", None),
+                CommitAndTag("feat: test", None),
+            ),
+            "",
+            1,
+            ("HEAD^^",),
+        ),
+    ),
+)
+def test_next_version_target(commisery_cli, commits, version, exitcode, target):
+    result = commisery_cli(commit_messages=commits, command="next-version", rev_range=target)
+    assert result.stdout.strip() == version
+    assert result.exit_code == exitcode
+
+
+def test_next_version_no_commits(commisery_cli):
+    result = commisery_cli(commit_messages=[], command="next-version", rev_range="")
+    assert result.stdout == ""
+    assert result.exit_code != 0
+
+
+def test_next_version_no_tags(commisery_cli):
+    result = commisery_cli(commit_messages=("test: no tags",), command="next-version", rev_range="")
+    assert result.stdout == ""
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize(
+    ("target", "exitcode", "log_content"),
+    (
+        (
+            ("HEAD^3",),
+            1,
+            "invalid",
+        ),
+        (
+            ("^HEAD^",),
+            1,
+            "empty commit list",
+        ),
+        (
+            ("HEAD^",),
+            0,
+            None,
+        ),
+    ),
+)
+def test_next_version_target(commisery_cli, caplog, target, exitcode, log_content):
+    result = commisery_cli(
+        commit_messages=(
+            CommitAndTag("docs: test", "1.0.1"),
+            CommitAndTag("fix: test", None),
+            CommitAndTag("feat: test", None),
+        ),
+        command="next-version",
+        rev_range=target,
+    )
+    if log_content is not None:
+        assert log_content in caplog.text
+
+    assert result.exit_code == exitcode
+
+
+@pytest.mark.parametrize(
+    ("msg", "version", "exitcode"),
+    (
+        (
+            "feat: add X",
+            "1.1.0",
+            0,
+        ),
+        (
+            "fix: replace bad with good",
+            "1.0.1",
+            0,
+        ),
+        (
+            "chore(componentA): cleanup",
+            "",
+            2,
+        ),
+    ),
+)
+def test_next_version_file(commisery_cli, tmp_path, msg, version, exitcode):
+    tmp_file = tmp_path / "test_commit_msg"
+    tmp_file.write_text(msg)
+
+    result = commisery_cli(
+        commit_messages=(CommitAndTag("docs: test", "1.0.0"),),
+        command="next-version",
+        rev_range=(str(tmp_file),),
+    )
+    assert result.stdout.strip() == version
+
+    assert result.exit_code == exitcode

--- a/commisery/test/util.py
+++ b/commisery/test/util.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 - 2022 TomTom N.V. (https://tomtom.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+
+class CommitAndTag(typing.NamedTuple):
+    message: str
+    tag: typing.Optional[str] = None

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
       'click-log',
       'GitPython>=3,<4',
       'regex',
+      'PyYAML',
       'stemming>=1,<2',
       'dataclasses>=0.8,<1; python_version < "3.7.0"',
       'llvm-diagnostics>=3.0.0,<4',


### PR DESCRIPTION
This subcommand will examine the current latest tag in the repo,
and, if a semver-compatible version tag is found, returns a bumped
semver reflecting the changes (in the form of Conventional Commits)
_since_ that tag.
