### PR TITLE
fix(next-version): allow detached HEADs

### DIFF
--- a/commisery/test/conftest.py
+++ b/commisery/test/conftest.py
@@ -28,10 +28,8 @@ except ImportError:
     import importlib_metadata as metadata
 
 
-if sys.version_info >= (3, 8):
-    _eps = metadata.entry_points().select(group="console_scripts")
-else:
-    _eps = metadata.entry_points()["console_scripts"]
+_eps = metadata.entry_points().select(group="console_scripts")
+
 commisery_range_cli = [ep for ep in _eps if ep.name == "cm"][0].load()
 
 

--- a/commisery/test/test_hopic.py
+++ b/commisery/test/test_hopic.py
@@ -37,10 +37,7 @@ try:
         (int(x) if re.match("^[0-9]+$", x) else x) for x in metadata.version("hopic").split(".")
     )
 
-    if sys.version_info >= (3, 8):
-        _eps = metadata.entry_points().select(group="console_scripts")
-    else:
-        _eps = metadata.entry_points()["console_scripts"]
+    _eps = metadata.entry_points().select(group="console_scripts")
     hopic_cli = [ep for ep in _eps if ep.name == "hopic"][0].load()
     from click.testing import CliRunner
     import git


### PR DESCRIPTION
This enables next-version to work on detached heads as well.

(GitPython is not great to write logic with for detecting bare or
empty repo's..)